### PR TITLE
Upgrade PropTypes and createClass

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,6 @@
-import React from 'react';
+import React from 'react'; // eslint-disable-line no-unused-vars
+import PropTypes from 'prop-types';
+import createClass from 'create-react-class';
 import hoistStatics from 'hoist-non-react-statics';
 
 const getDisplayName = Component => (
@@ -21,10 +23,10 @@ export function injectDeps(context, _actions) {
   }
 
   return function (Component) {
-    const ComponentWithDeps = React.createClass({
+    const ComponentWithDeps = createClass({
       childContextTypes: {
-        context: React.PropTypes.object,
-        actions: React.PropTypes.object
+        context: PropTypes.object,
+        actions: PropTypes.object
       },
 
       getChildContext() {
@@ -51,7 +53,7 @@ const defaultMapper = (context, actions) => ({
 
 export function useDeps(mapper = defaultMapper) {
   return function (Component) {
-    const ComponentUseDeps = React.createClass({
+    const ComponentUseDeps = createClass({
       render() {
         const {context, actions} = this.context;
         const mappedProps = mapper(context, actions);
@@ -65,8 +67,8 @@ export function useDeps(mapper = defaultMapper) {
       },
 
       contextTypes: {
-        context: React.PropTypes.object,
-        actions: React.PropTypes.object
+        context: PropTypes.object,
+        actions: PropTypes.object
       }
     });
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
   },
   "dependencies": {
     "babel-runtime": "6.x.x",
-    "hoist-non-react-statics": "1.x.x"
+    "create-react-class": "^15.6.2",
+    "hoist-non-react-statics": "1.x.x",
+    "prop-types": "^15.6.0"
   }
 }


### PR DESCRIPTION
Starting with React 15.6, React.PropTypes and React.createClass are
deprecated. Added the recommended dropin replacements and updated
the references.